### PR TITLE
Fix ORM link, tracker link formatting and rewriting wording.

### DIFF
--- a/pages/source/error.rst
+++ b/pages/source/error.rst
@@ -6,7 +6,7 @@ The page you visited could not be found.
 Are you looking for documentation?
 
 * `ORM Documentation
-  <http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/">`_
+  <http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/>`_
 * `DBAL Documentation
   <http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/>`_
 * `Common Documentation
@@ -17,5 +17,6 @@ Are you looking for documentation?
   <http://docs.doctrine-project.org/projects/doctrine-couchdb-odm/en/latest/>`_
 
 You reached this page from Google or any other search engine? Please open
-`a ticket on the website tracker <https://github.com/doctrine/doctrine-website-sphinx/issues>`.
- and we look into rewriting urls to the current location of the docs.
+`a ticket on the website tracker <https://github.com/doctrine/doctrine-website-sphinx/issues>`_.
+
+We are looking into rewriting URLs to the current location of the docs.


### PR DESCRIPTION
Noticed there are a couple of small issues on the error page:
- the ORM Documentation link was broken
- the website tracker link formatting was incorrect
- the wording for "and we look into rewriting urls to the current location of the docs." seemed a little clumsy. 
