### PR TITLE
Fix link to DBAL documentation

### DIFF
--- a/site/_themes/doctrine/aggregated.html
+++ b/site/_themes/doctrine/aggregated.html
@@ -44,7 +44,7 @@
 
     <ul>
         <li><a class="reference internal" href="/projects/orm.html">Object-Relational Mapper (ORM)</a></li>
-        <li><a class="reference internal" href="/projects/orm.html">Database Abstraction Layer (DBAL)</a></li>
+        <li><a class="reference internal" href="/projects/dbal.html">Database Abstraction Layer (DBAL)</a></li>
         <li><a class="reference internal" href="/projects/mongodb-odm.html">MongoDB Document Mapper</a></li>
         <li><a class="reference internal" href="/projects/phpcr-odm.html">PHPCR Document Mapper</a></li>
         <li><a class="reference internal" href="/projects/common.html">Common Libraries</a></li>


### PR DESCRIPTION
Fixes the link to the DBAL documentation on the main page.
