### PR TITLE
Updating Installation Instructions

### DIFF
--- a/site/2014/12/04/doctrine_dbal_2_5_release.rst
+++ b/site/2014/12/04/doctrine_dbal_2_5_release.rst
@@ -14,7 +14,7 @@ release master since version 2.0.
 You can install DBAL through Composer:
 
 .. code-block:: shell
-    composer require doctrine/dbal
+    composer require doctrine/dbal:~2.5
 
 This version is mostly backwards compatible with only some minor breaks, when
 using PDO IBM, creating a custom platform or using non-default DateTime

--- a/site/2014/12/04/doctrine_dbal_2_5_release.rst
+++ b/site/2014/12/04/doctrine_dbal_2_5_release.rst
@@ -13,13 +13,8 @@ release master since version 2.0.
 
 You can install DBAL through Composer:
 
-.. code-block:: json
-
-    {
-        "require": {
-            "doctrine/dbal": "2.5.0"
-        }
-    }
+.. code-block:: shell
+    composer require doctrine/dbal
 
 This version is mostly backwards compatible with only some minor breaks, when
 using PDO IBM, creating a custom platform or using non-default DateTime


### PR DESCRIPTION
Composer is now able to select the latest compatible release when a library is requested via `composer require`, this is the recommended way of installing new packages. Editing the json file is not recommended and may cause other issues if a bad update/install is executed afterwards. `require` is an all in one solution that completes the whole process with less chance for mistakes.