### PR TITLE
Use pip to install all project dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ plugins that generate project details and hooks into Github.
 
 The contents of the page are located in `site/` directory.
 
+## Installation
+
+1. Clone this repository.
+2. From the root repository directory install all dependencies:
+
+        $ pip install -r requirements.txt
+
+## Contributing
+
 To write a new blog post just `cd site/` and then call the following to create a draft:
 
     $ tinker -d "Title of Post"
@@ -12,4 +21,3 @@ To write a new blog post just `cd site/` and then call the following to create a
 Open a pull request with the draft and we will publish it once accepted.
 
 You can build and view the page by callling `tinker -b` in the `site/` directory.
-Make sure to `sudo pip install tinkerer` to get the required dependencies.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML~=3.10
+Tinkerer~=1.5


### PR DESCRIPTION
I tried following the README to build the site locally on Mac OS 10.9.5 + Homebrew:

    $ pip install tinkerer
    $ cd site
    $ tinker -b
    Running Sphinx v1.3.3
    
    Extension error:
    Could not import extension doctrineprojects (exception: No module named yaml)

The doctrineprojects Tinkerer extension relies on a Python YAML package, which I didn't have installed. This was fixed by installing PyYAML:

    $ pip install pyyaml
    $ tinker -b
    Running Sphinx v1.3.3
    ...
    build succeeded, 88 warnings.

Since this project already recommends using pip to install tinkerer we can create a `requirements.txt` ([see docs](https://pip.pypa.io/en/stable/user_guide/#requirements-files)) to install all Python-related dependencies. I've updated the README and provided some version constraints.

Note: Before submitting this PR I only vaguely knew about pip and requirements.txt. Hopefully I did everything right!

Thanks! :rocket: 