### PR TITLE
Fix documentation link on downloads page

### DIFF
--- a/site/_exts/doctrinedownloads.py
+++ b/site/_exts/doctrinedownloads.py
@@ -70,7 +70,7 @@ def visit_doctrinedownloads_html(self, node):
     self.body.append('<ul class="nav nav-pills project-pills">')
     self.body.append('<li class="latest-version"><a href="#version%s">Latest Version: %s</a></li>' % (node['project']['latest_version'], node['project']['latest_version']))
     self.body.append('<li><a href="%s">Issues</a></li>\n' % (node['project']['issues_link']) )
-    self.body.append('<li><a href="http://docs.doctrine-project.org/projects/doctrine-%s/latest/en">Latest Documentation</a></li>\n' % (node['project']['slug']) )
+    self.body.append('<li><a href="http://docs.doctrine-project.org/projects/doctrine-%s/en/latest">Latest Documentation</a></li>\n' % (node['project']['slug']) )
     self.body.append('<li><a href="/api/%s/%s/index.html">Latest API</a></li>\n' % (node['project']['slug'], node['project']['latest_version']) )
     self.body.append('<li><a href="%s">Browse Source</a></li>\n' % (node['project']['browse_source_link']) )
     self.body.append('</ul>')
@@ -96,7 +96,7 @@ def visit_doctrinedownloads_html(self, node):
         self.body.append('<div class="panel-body">')
 
         self.body.append('<ul class="nav nav-pills version-pills">');
-        self.body.append('<li><a href="http://docs.doctrine-project.org/projects/doctrine-%s/latest/en">Latest Documentation</a></li>\n' % (node['project']['slug']) )
+        self.body.append('<li><a href="http://docs.doctrine-project.org/projects/doctrine-%s/en/latest">Latest Documentation</a></li>\n' % (node['project']['slug']) )
         self.body.append('<li><a href="/api/%s/%s/index.html">API (%s)</a></li>\n' % (node['project']['slug'], version, version) )
         self.body.append('</ul>')
 


### PR DESCRIPTION
Currently pointing to: http://doctrine-orm.readthedocs.io/projects/doctrine-orm/latest/en
But the correct one is: http://doctrine-orm.readthedocs.io/projects/doctrine-orm/en/latest