### PR TITLE
use the fully qualified class name

### DIFF
--- a/site/about.rst
+++ b/site/about.rst
@@ -328,7 +328,7 @@ blog post for more information on the DBAL.
         'host' => 'localhost',
         'driver' => 'pdo_mysql',
     );
-    $conn = DriverManager::getConnection($connectionParams, $config);
+    $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
 
     $articles = $conn->fetchAll('select * from articles');
 


### PR DESCRIPTION
Without the fully qualified class name (FQCN) it does not work and throws an uncaught error.
`PHP Fatal error:  Uncaught Error: Class 'DriverManager' not found`&hellip;

This PR fixes this and updates the readme to include the FQCN in the code example.

Or add `use Doctrine\DBAL\DriverManager;`